### PR TITLE
Rearrange the output files so that the server can actually be built

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/go/GoServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/GoServerCodegen.java
@@ -18,7 +18,6 @@ public class GoServerCodegen extends AbstractGoCodegen {
     protected String apiVersion = "1.0.0";
     protected int serverPort = 8080;
     protected String projectName = "swagger-server";
-    protected String apiPath = "go";
 
     public GoServerCodegen() {
         super();
@@ -86,7 +85,6 @@ public class GoServerCodegen extends AbstractGoCodegen {
          */
         additionalProperties.put("apiVersion", apiVersion);
         additionalProperties.put("serverPort", serverPort);
-        additionalProperties.put("apiPath", apiPath);
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
 
         modelPackage = packageName;
@@ -98,16 +96,11 @@ public class GoServerCodegen extends AbstractGoCodegen {
          * it will be processed by the template engine.  Otherwise, it will be copied
          */
         supportingFiles.add(new SupportingFile("swagger.mustache", "api", "swagger.yaml"));
-        supportingFiles.add(new SupportingFile("Dockerfile", "", "Dockerfile"));
-        supportingFiles.add(new SupportingFile("main.mustache", "", "main.go"));
-        supportingFiles.add(new SupportingFile("routers.mustache", apiPath, "routers.go"));
-        supportingFiles.add(new SupportingFile("logger.mustache", apiPath, "logger.go"));
-        writeOptional(outputFolder, new SupportingFile("README.mustache", apiPath, "README.md"));
-    }
-
-    @Override
-    public String apiPackage() {
-        return apiPath;
+        supportingFiles.add(new SupportingFile("Dockerfile", "extra", "Dockerfile"));
+        supportingFiles.add(new SupportingFile("main.mustache", "extra", "main.go"));
+	supportingFiles.add(new SupportingFile("routers.mustache", "", "routers.go"));
+        supportingFiles.add(new SupportingFile("logger.mustache", "", "logger.go"));
+        writeOptional(outputFolder, new SupportingFile("README.mustache", "", "README-server.md"));
     }
 
     /**
@@ -150,11 +143,11 @@ public class GoServerCodegen extends AbstractGoCodegen {
      */
     @Override
     public String apiFileFolder() {
-        return outputFolder + File.separator + apiPackage().replace('.', File.separatorChar);
+	return  String.join(File.separator, outputFolder);
     }
 
     @Override
     public String modelFileFolder() {
-        return outputFolder + File.separator + apiPackage().replace('.', File.separatorChar);
+        return String.join(File.separator, outputFolder);
     }
 }

--- a/src/main/resources/handlebars/go-server/Dockerfile
+++ b/src/main/resources/handlebars/go-server/Dockerfile
@@ -1,14 +1,19 @@
-FROM golang:1.10 AS build
+FROM golang:1.20 AS build
 WORKDIR /go/src
-COPY go ./go
-COPY main.go .
+COPY . .
 
+# If you have set -DpackageName when running swagger-codegen, then
+# replace "swagger" with your package name.
+RUN go mod init swagger
+RUN go mod tidy
+
+# The combination of cgo and net/http causes go to build a shared
+# exectable. By turning off cgo we get a fully static executable which
+# works much more easily in a container.
 ENV CGO_ENABLED=0
-RUN go get -d -v ./...
-
-RUN go build -a -installsuffix cgo -o swagger .
+RUN go build extra/main.go
 
 FROM scratch AS runtime
-COPY --from=build /go/src/swagger ./
+COPY --from=build /go/src/main ./
 EXPOSE 8080/tcp
-ENTRYPOINT ["./swagger"]
+ENTRYPOINT ["./main"]

--- a/src/main/resources/handlebars/go-server/README.mustache
+++ b/src/main/resources/handlebars/go-server/README.mustache
@@ -22,9 +22,10 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}})
 
 
 ### Running the server
-To run the server, follow these simple steps:
+
+An example ``main.go`` file has been generated in the ``extra``
+directory so that you can run the server with the following command.
 
 ```
-go run main.go
+go run extra/main.go
 ```
-

--- a/src/main/resources/handlebars/go-server/main.mustache
+++ b/src/main/resources/handlebars/go-server/main.mustache
@@ -1,24 +1,23 @@
 {{>partial_header}}
 package main
 
+// This is a sample main function.
+//
+// You can compile it and the server API code from the output
+// directory with the command "go build extra/main.go". This will give
+// you and executable file in the output directory called "main".
+
 import (
 	"log"
 	"net/http"
 
-	// WARNING!
-	// Change this to a fully-qualified import path
-	// once you place this file into your project.
-	// For example,
-	//
-	//    sw "github.com/myname/myrepo/{{apiPath}}"
-	//
-	sw "./{{apiPath}}"
+	"{{packageName}}"
 )
 
 func main() {
 	log.Printf("Server started")
 
-	router := sw.NewRouter()
+	router := {{packageName}}.NewRouter()
 
 	log.Fatal(http.ListenAndServe(":{{serverPort}}", router))
 }


### PR DESCRIPTION
Rearrange the output files so that the server can actually be built with go build running in module mode (the modern way of running go build).

main.go now builds without user intervention.

The Dockerfile and README have been updated to match the new directory structure. Dockerfile has been refreshed to build with the latest Go and to use the modern module mode for building.

This fixes issue #2 and issue #6.