### PR TITLE
Remove the unnecessary definition of an anonymous variable with type context.Context because it offends me

### DIFF
--- a/src/main/resources/handlebars/go/api.mustache
+++ b/src/main/resources/handlebars/go/api.mustache
@@ -13,11 +13,6 @@ import (
 {{/imports}}
 )
 
-// Linger please
-var (
-	_ context.Context
-)
-
 type {{classname}}Service service
 {{#operation}}
 {{#contents}}


### PR DESCRIPTION
This closes #5 .