### PR TITLE
Issue/contexts

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/go/GoServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/GoServerCodegen.java
@@ -98,6 +98,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
         supportingFiles.add(new SupportingFile("swagger.mustache", "api", "swagger.yaml"));
         supportingFiles.add(new SupportingFile("Dockerfile", "extra", "Dockerfile"));
         supportingFiles.add(new SupportingFile("main.mustache", "extra", "main.go"));
+        supportingFiles.add(new SupportingFile("stubs.mustache", "extra", "stubs.go"));
 	supportingFiles.add(new SupportingFile("routers.mustache", "", "routers.go"));
         supportingFiles.add(new SupportingFile("logger.mustache", "", "logger.go"));
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.go"));

--- a/src/main/resources/handlebars/go-server/stubs.mustache
+++ b/src/main/resources/handlebars/go-server/stubs.mustache
@@ -1,31 +1,13 @@
-{{>partial_header}}
 package {{packageName}}
+
+{{>partial_header}}
+
 {{#apiInfo}}
 
 import (
 	"net/http"
 )
-
-// This file should contain a full set of stub handlers for your web
-// server application. If it does, then you can just copy this file
-// into your application and start replacing the stubs with real code.
-
-// swagger-codegen has an interesting "feature" where API information is
-// not available to supporting files if you aren't also generating the
-// APIs at the same time. In that case this file will contain no
-// functions at all and you will need to copy and paste the stub handler
-// from the comment below into your code. The function names you need to
-// use are whatever undefined errors you get from compiling all the
-// api_X.go files.
-
-/*
-
-func STUB_HANDLER(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
-}
-
-*/{{#apis}}
+{{#apis}}
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -36,4 +18,25 @@ func STUB_HANDLER(w http.ResponseWriter, r *http.Request) {
 func {{nickname}}(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+}
+{{/operation}}{{/operations}}{{/apis}}
+{{^apis}}
+
+// If you are seeing this comment then you are using a version of
+// swagger-codegen that only collections API information when it is
+// generating the API source code (i.e. when -Dapis is specified on the
+// command line). This does make putting API related information (such as
+// API stubs) into supporting files a bit difficult.
+
+// Each stub looks like the following function. The STUB_HANDLER names
+// will be the long list of undefined names that Go will complain
+// about if you try compile your server without any stubs. Also, they'll
+// be the operation IDs from your OpenAPI spec if you have defined an
+// operation IDs.
+
+func STUB_HANDLER(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+}
+{{/apis}}
+{{/apiInfo}}

--- a/src/main/resources/handlebars/go/README.mustache
+++ b/src/main/resources/handlebars/go/README.mustache
@@ -61,22 +61,16 @@ Class | Method | HTTP request | Description
 
 Example
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
-	Key: "APIKEY",
-	Prefix: "Bearer", // Omit if not necessary.
-})
-r, err := client.Service.Operation(auth, args)
+client.SetAPIKey("APIKEY")
+r, err := client.Service().Operation(args)
 ```
 {{/isApiKey}}
 {{#isBasic}}- **Type**: HTTP basic authentication
 
 Example
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
-	UserName: "username",
-	Password: "password",
-})
-r, err := client.Service.Operation(auth, args)
+client.SetBasicAuth("username", "password")
+r, err := client.Service().Operation(args)
 ```
 {{/isBasic}}
 {{#isOAuth}}- **Type**: OAuth
@@ -86,21 +80,23 @@ r, err := client.Service.Operation(auth, args)
 {{#each scopes}} - **{{@key}}**: {{this}}
 {{/each}}
 
-Example
+Example using an HTTP client from the oauth2 library to automatically
+refresh tokens and perform user authentication.
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
-r, err := client.Service.Operation(auth, args)
-```
-
-Or via OAuth2 module to automatically refresh tokens and perform user authentication.
-```golang
-import "golang.org/x/oauth2"
+import (
+	"context"
+	"golang.org/x/oauth2"
+)
 
 /* Perform OAuth2 round trip request and obtain a token */
+conf := ... // a *oauth2.Config
+token := ... // your access token (*oauth2.Token)
+httpClient := conf.Client(context.Background(), token)
 
-tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
-r, err := client.Service.Operation(auth, args)
+cfg := NewConfiguration()
+cfg.HTTPClient = httpClient
+client := NewAPIClient(cfg)
+r, err := client.Service().Operation(args)
 ```
 {{/isOAuth}}
 {{/authMethods}}

--- a/src/main/resources/handlebars/go/api.mustache
+++ b/src/main/resources/handlebars/go/api.mustache
@@ -64,7 +64,12 @@ ctx - for authentication, logging, cancellation, deadlines, tracing, etc. Passed
 
 {{{nickname}}} returns a {{{returnType}}} on success and returns error != nil on failure.{{/returnType}}
 */
-func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
+func (a *{{{classname}}}Service) {{{nickname}}}({{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
+	return a.{{{nickname}}}WithContext(context.Background(){{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals{{/hasOptionalParams}})
+}
+
+// {{{nickname}}}WithContext is the same as {{{nickname}}} with a context.Context parameter.
+func (a *{{{classname}}}Service) {{{nickname}}}WithContext(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("{{httpMethod}}")
 		localVarPostBody   interface{}
@@ -223,25 +228,39 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 {{/hasBodyParam}}
 {{#authMethods}}
 {{#isApiKey}}
-	if ctx != nil {
-		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
-			var key string
-			if auth.Prefix != "" {
-				key = auth.Prefix + " " + auth.Key
-			} else {
-				key = auth.Key
-			}
-			{{#isKeyInHeader}}localVarHeaderParams["{{keyParamName}}"] = key{{/isKeyInHeader}}
-			{{#isKeyInQuery}}localVarQueryParams.Add("{{keyParamName}}", key){{/isKeyInQuery}}
-		}
-	}
+{{#isKeyInHeader}}
+
+	localVarHeaderParams["{{keyParamName}}"] = a.apiKey
+
+{{/isKeyInHeader}}
+{{#isKeyInQuery}}
+
+	localVarQueryParams.Add("{{keyParamName}}", a.apiKey)
+
+{{/isKeyInQuery}}
 {{/isApiKey}}
+{{#isBearer}}
+
+	localVarHeaderParams["Authorization"] = a.authToken
+{{/isBearer}}
 {{/authMethods}}
 	r, err := a.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}err
 	}
+{{#authMethods}}
+{{#isApiKey}}
+{{#isKeyInCookie}}
+	// swagger-codegen doesn't understand API keys in cookies
+	// so this code will never be generated
+	r.AddCookie(&Cookie{Name: "{{keyParamName}}", Value: a.apiKey})
+{{/isKeyInCookie}}
+{{/isApiKey}}
+{{#isBasic}}
+
+	r.SetBasicAuth(a.username, a.password)
+{{/isBasic}}
+{{/authMethods}}
 
 	localVarHttpResponse, err := a.callAPI(r)
 	if err != nil || localVarHttpResponse == nil {

--- a/src/main/resources/handlebars/go/client.mustache
+++ b/src/main/resources/handlebars/go/client.mustache
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
-
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -33,7 +31,11 @@ var (
 // APIClient manages communication with the {{appName}} API v{{version}}
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
-	cfg Configuration
+	cfg       Configuration
+	username  string
+	password  string
+	authToken string	// Only "Bearer" tokens are supported
+	apiKey    string
 }
 
 // NewAPIClient creates a new API client using the provided
@@ -49,6 +51,26 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c.cfg = *cfg
 
 	return c
+}
+
+// SetBasicAuth records a username and password in an APIClient that
+// will be used to authorise all subsequent requests made by that
+// APIClient.
+func (c *APIClient) SetBasicAuth (username, password string) {
+	c.username = username
+	c.password = password
+}
+
+// SetBearerToken records a bearer token to be used to authorise all
+// subsequent requests made by that APIClient.
+func (c *APIClient) SetBearerToken (token string) {
+	c.authToken = "Bearer " + token
+}
+
+// SetAPIKey records an API key to be used to authorise all
+// subsequent requests made by that APIClient.
+func (c *APIClient) SetAPIKey (apiKey string) {
+	c.apiKey = apiKey
 }
 
 func atoi(in string) (int, error) {
@@ -260,29 +282,6 @@ func (c *APIClient) prepareRequest(
 	if ctx != nil {
 		// add context to the request
 		localVarRequest = localVarRequest.WithContext(ctx)
-
-		// Walk through any authentication.
-
-		// OAuth2 authentication
-		if tok, ok := ctx.Value(ContextOAuth2).(oauth2.TokenSource); ok {
-			// We were able to grab an oauth2 token from the context
-			var latestToken *oauth2.Token
-			if latestToken, err = tok.Token(); err != nil {
-				return nil, err
-			}
-
-			latestToken.SetAuthHeader(localVarRequest)
-		}
-
-		// Basic HTTP Authentication
-		if auth, ok := ctx.Value(ContextBasicAuth).(BasicAuth); ok {
-			localVarRequest.SetBasicAuth(auth.UserName, auth.Password)
-		}
-
-		// AccessToken Authentication
-		if auth, ok := ctx.Value(ContextAccessToken).(string); ok {
-			localVarRequest.Header.Add("Authorization", "Bearer "+auth)
-		}
 	}
 
 	for header, value := range c.cfg.DefaultHeader {

--- a/src/main/resources/handlebars/go/configuration.mustache
+++ b/src/main/resources/handlebars/go/configuration.mustache
@@ -6,42 +6,6 @@ import (
 	"net/http"
 )
 
-// contextKeys are used to identify the type of value in the context.
-// Since these are string, it is possible to get a short description of the
-// context key for logging and debugging using key.String().
-
-type contextKey string
-
-func (c contextKey) String() string {
-	return "auth " + string(c)
-}
-
-var (
-	// ContextOAuth2 takes a oauth2.TokenSource as authentication for the request.
-	ContextOAuth2 = contextKey("token")
-
-	// ContextBasicAuth takes BasicAuth as authentication for the request.
-	ContextBasicAuth = contextKey("basic")
-
-	// ContextAccessToken takes a string oauth2 access token as authentication for the request.
-	ContextAccessToken = contextKey("accesstoken")
-
-	// ContextAPIKey takes an APIKey as authentication for the request
-	ContextAPIKey = contextKey("apikey")
-)
-
-// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth
-type BasicAuth struct {
-	UserName string `json:"userName,omitempty"`
-	Password string `json:"password,omitempty"`
-}
-
-// APIKey provides API key based authentication to a request passed via context using ContextAPIKey
-type APIKey struct {
-	Key    string
-	Prefix string
-}
-
 // Configuration provides all of the information needed to configure
 // an APIClient.
 type Configuration struct {


### PR DESCRIPTION
Each API endpoint now has two client interfaces, one with a context and one without. 

All use of contexts for auth has been removed.

There are three simple methods for the APIClient type that register autentication credentials and there is no longer any way to supply Oauth 2 tokens. You can still supply an Oauth 2 customised HTTP client which, quite frankly, is the right way to do it.

The API client knows which credentials to send to which endpoints because that's specified in the OpenAPI input. There is no need for the developer to code that into each API call.