### PR TITLE
Use pointer for optional parameters

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -354,7 +354,6 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
             }
         }
 
-        boolean addedOptionalImport = false;
         boolean addedTimeImport = false;
         boolean addedOSImport = false;
         for (CodegenOperation operation : operations) {
@@ -366,24 +365,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
                         addedOSImport = true;
                     }
 
-                    // import "time" if the operation has a required time parameter.
-                    if (param.required) {
-                        if (!addedTimeImport && param.dataType == "time.Time") {
-                            imports.add(createMapping("import", "time"));
-                            addedTimeImport = true;
-                        }
-                    } else {
-                        if (!addedOptionalImport) {
-                            imports.add(createMapping("import", "github.com/antihax/optional"));
-                            addedOptionalImport = true;
-                        }
-                        // We need to specially map Time type to the optionals package
-                        if (param.dataType == "time.Time") {
-                            param.vendorExtensions.put("x-optionalDataType", "Time");
-                            continue;
-                        }
-                        // Map optional type to dataType
-                        param.vendorExtensions.put("x-optionalDataType", param.dataType.substring(0, 1).toUpperCase() + param.dataType.substring(1));
+                    // import "time" if the operation has a time parameter.
+		    if (!addedTimeImport && param.dataType == "time.Time") {
+			imports.add(createMapping("import", "time"));
+			addedTimeImport = true;
                     }
                 }
             }

--- a/src/main/resources/handlebars/go/api.mustache
+++ b/src/main/resources/handlebars/go/api.mustache
@@ -29,47 +29,29 @@ func (c *APIClient) {{classname}}Service () *{{classname}}Service {
 {{#operation}}
 {{#contents}}
 {{#@first}}
-{{#hasOptionalParams}}
-
-type {{{classname}}}{{{nickname}}}Opts struct {
-{{#parameters}}
-{{^required}}
-{{#isPrimitiveType}}
-{{#isFile}}
-    {{vendorExtensions.x-exportParamName}} optional.Interface
-{{/isFile}}
-{{^isFile}}
-    {{vendorExtensions.x-exportParamName}} optional.{{vendorExtensions.x-optionalDataType}}
-{{/isFile}}
-{{/isPrimitiveType}}
-{{^isPrimitiveType}}
-    {{vendorExtensions.x-exportParamName}} optional.Interface
-{{/isPrimitiveType}}
-{{/required}}
-{{/parameters}}
-}
-{{/hasOptionalParams}}
 
 /*
 {{{nickname}}}{{#summary}} {{.}}{{/summary}}{{#notes}}
 {{notes}}{{/notes}}
 
-The parameters for {{{nickname}}} are:
+The required parameters for {{{nickname}}} are:
 ctx - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 {{#parameters}}{{#required}}{{paramName}}{{#description}} - {{.}}{{/description}}
-{{/required}}{{/parameters}}{{#hasOptionalParams}}optional nil or *{{{classname}}}{{{nickname}}}Opts - Optional Parameters:
-{{#parameters}}{{^required}}     {{vendorExtensions.x-exportParamName}} ({{#isPrimitiveType}}optional.{{vendorExtensions.x-optionalDataType}}{{/isPrimitiveType}}{{^isPrimitiveType}}optional.Interface of {{dataType}}{{/isPrimitiveType}}) - {{#description}} {{.}}{{/description}}
+{{/required}}{{/parameters}}{{#hasOptionalParams}}
+
+The following parameters are optional and may be nil.
+{{#parameters}}{{^required}}{{paramName}}{{#description}} - {{.}}{{/description}}
 {{/required}}{{/parameters}}{{/hasOptionalParams}}
 {{#returnType}}
 
 {{{nickname}}} returns a {{{returnType}}} on success and returns error != nil on failure.{{/returnType}}
 */
-func (a *{{{classname}}}Service) {{{nickname}}}({{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
-	return a.{{{nickname}}}WithContext(context.Background(){{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals{{/hasOptionalParams}})
+func (a *{{{classname}}}Service) {{{nickname}}}({{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}{{#parameters}}{{^required}}{{paramName}} *{{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
+	return a.{{{nickname}}}WithContext(context.Background(){{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}{{#parameters}}{{^required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{/hasOptionalParams}})
 }
 
 // {{{nickname}}}WithContext is the same as {{{nickname}}} with a context.Context parameter.
-func (a *{{{classname}}}Service) {{{nickname}}}WithContext(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}localVarOptionals *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
+func (a *{{{classname}}}Service) {{{nickname}}}WithContext(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#parameters}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{#hasOptionalParams}}{{#parameters}}{{^required}}{{paramName}} *{{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/parameters}}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("{{httpMethod}}")
 		localVarPostBody   interface{}
@@ -138,8 +120,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}WithContext(ctx context.Context{{
 	localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	{{/required}}
 	{{^required}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	if {{paramName}} != nil {
+		localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	}
 	{{/required}}
 	{{/queryParams}}


### PR DESCRIPTION
We used to use the optional package from antihax, but that was overkill.

Closes #13 